### PR TITLE
PLAT-113150: Merge props to override properly

### DIFF
--- a/src/renderers.js
+++ b/src/renderers.js
@@ -306,7 +306,7 @@ function defaultComponentRenderer ({section, renderer, imports, typeRenderer = r
 
 	return `${propsInterface}
 		${renderDescription(section)}
-		export class ${section.name} extends React.Component<Merge<React.HTMLProps<HTMLElement>, ${propsInterfaceName}> {
+		export class ${section.name} extends React.Component<Merge<React.HTMLProps<HTMLElement>, ${propsInterfaceName}>> {
 			${
 				renderer({section: funcs, export: false, instance: true})
 					.filter(Boolean)


### PR DESCRIPTION
If a component prop and a React Element prop conflicted, Typescript would not include the component prop.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com