### PR TITLE
Revert "WRP-864: Added the rendering of static members for a component"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## unreleased
 
-* Added the rendering of static members for a component.
 * Fixed security vulnerabilities.
 
 ## [0.1.2] (May 31, 2022)

--- a/src/renderers.js
+++ b/src/renderers.js
@@ -292,11 +292,11 @@ exports.defaultHocRenderer = defaultHocRenderer;
 function defaultComponentRenderer ({section, renderer, imports, typeRenderer = renderType}) {
 	const props = section.members.instance.filter(member => !member.kind);
 	const funcs = section.members.instance.filter(member => member.kind === 'function');
+
 	const omits = section.tags.reduce((res, tag) => tag.title === 'omit' ? res.concat(tag.description) : res, []);
 	const propsBase = calcPropsBaseName({imports, section});
 	const propsInterfaceName = `${section.name}Props`;
 	const propsInterface = renderInterface(propsInterfaceName, props, propsBase, typeRenderer, imports, omits);
-	let staticMembersDescriptionArray = [], staticMembersDescription = '';
 
 	imports.add({
 		module: 'react',
@@ -304,14 +304,6 @@ function defaultComponentRenderer ({section, renderer, imports, typeRenderer = r
 		all: true
 	});
 
-	if (section.members.static.length > 0) {
-		for (let i = 0; i < section.members.static.length; i++) {
-			const tagName = section.members.static[i].tags.reduce((res, tag) => tag.title === 'name' ? res + tag.name : res, []);
-			const linkName = section.members.static[i].description.children[0].children.reduce((res, tag) => tag.type === 'link' ? res + tag.url.split('.')[1] : res, []);
-			staticMembersDescriptionArray.push(renderDescription(section.members.static[i]) + linkName + ' : ' + tagName + '\n\n');
-		}
-		staticMembersDescription = staticMembersDescriptionArray.reduce((acc, current) => acc + current + '\n');
-	}
 	return `${propsInterface}
 		${renderDescription(section)}
 		export class ${section.name} extends React.Component<Merge<React.HTMLProps<HTMLElement>, ${propsInterfaceName}>> {
@@ -320,7 +312,6 @@ function defaultComponentRenderer ({section, renderer, imports, typeRenderer = r
 					.filter(Boolean)
 					.join('\n')
 			}
-			${staticMembersDescription}
 		}
 	`;
 }


### PR DESCRIPTION
Reverts enactjs/jsdoc-to-ts#19

Reason: After this PR, error logs occur when jsdoc-to-ts is operated on sandstone.

> Unable to process Alert: SyntaxError: Unexpected token. A constructor, method, accessor, or property was expected. (23:2)
  21 | a specific component size.
  22 |  */
> 23 |  : 
     |  ^
  24 |
  25 | /**
  26 |  * Type of image to appear in the alert component. There are two types:
SyntaxError: Unexpected token. A constructor, method, accessor, or property was expected. (23:2)
  21 | a specific component size.
  22 |  */
> 23 |  : 
     |  ^
  24 |
  25 | /**
  26 |  * Type of image to appear in the alert component. There are two types:
    at k (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/parser-typescript.js:1:15163)
    at cT (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/parser-typescript.js:257:10765)
    at Object.uT [as parse] (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/parser-typescript.js:257:11074)
    at Object.parse (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/index.js:7331:23)
    at coreFormat (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/index.js:8645:18)
    at formatWithCursor2 (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/index.js:8837:18)
    at /home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/index.js:37832:12
    at Object.format (/home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/node_modules/prettier/index.js:37846:12)
    at /home/taeyoung.hong/webos_build_server/WRP-4413/jsdoc-to-ts/index.js:32:23