### PR TITLE
WRP-21114: Generated ts file is empty if a module is marked as private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [unreleased]
+
+### Fixed
+
+* If a module is marked as private `.ts` file will not be generated.
+
 ## [1.0.0] (July 5, 2023)
 
 * Migrated project to ESM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-* Fixed generation of empty `.ts` file for the private module.
+* Fixed generation of empty `.ts` file for private modules.
 * Updated `glob` to the latest major version `^10.3.1` and refactored code to use promises instead of callbacks. 
 
 ## [1.0.0] (July 5, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-* Fixed generation of empty `.ts` file for private modules.
+* Fixed to prevent empty `.ts` file generation for private modules.
 * Updated `glob` to the latest major version `^10.3.1` and refactored code to use promises instead of callbacks. 
 
 ## [1.0.0] (July 5, 2023)

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function parse ({path: modulePath, files, format, importMap, output}) {
 			const firstNamedEntry = root.find(entry => entry.name);
 			let moduleName = firstNamedEntry ? firstNamedEntry.name : '';
 
-			if (!result.length) {
+			if (!result.replace(/\s/g, '').length) {
 				return;
 			}
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ async function parse ({path: modulePath, files, format, importMap, output}) {
 			const firstNamedEntry = root.find(entry => entry.name);
 			let moduleName = firstNamedEntry ? firstNamedEntry.name : '';
 
+			if (!result.length) {
+				return;
+			}
+
 			if (format) {
 				result = prettier.format(result, {parser: 'typescript'});
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Generated ts file is empty if a module is marked as private


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If a file after all conversions will be empty, it will not be generated


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21114


### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com